### PR TITLE
 /register Url bug fix in UserController.java

### DIFF
--- a/src/main/java/com/org/controller/UserController.java
+++ b/src/main/java/com/org/controller/UserController.java
@@ -50,7 +50,7 @@ public class UserController {
 			return "signup";
 		}
 
-		return "index";
+		return "redirect:/";
 	}
 
 	@GetMapping("/login")


### PR DESCRIPTION
Previously when  the user Signsup successfully it was traversing the user to index page but in the url it was still displaying as /register which mean the user is signup page so now I have modified that logic, now if a user signsup successfully it will redirect to index page but in the url it wont display /register endpoint anymore.